### PR TITLE
fix: #1 Set isUserInteractionEnabled to true for canvasView on iOS 15

### DIFF
--- a/Sources/SecureView/SecureView.swift
+++ b/Sources/SecureView/SecureView.swift
@@ -82,6 +82,7 @@ public final class SecureView<ScreenView: UIView, ScreenshotView: UIView>: UIVie
             fatalError("Unable to extract secured canvas view")
         }
         canvasView.subviews.forEach { $0.removeFromSuperview() }
+        canvasView.isUserInteractionEnabled = true
         self.canvasView = canvasView
         
     }


### PR DESCRIPTION
It was observed that on iOS 15, `isUserInteractionEnabled` was set to `false` by default on `canvasView`, preventing interaction with its subview `contentView`. This change ensures the `contentView` is interactive.